### PR TITLE
don't use fn.name

### DIFF
--- a/src/ConcatModule.hs
+++ b/src/ConcatModule.hs
@@ -50,7 +50,7 @@ replaceRequire Dependency {requiredAs, filePath} body =
   T.pack $ subRegex requireRegex (T.unpack body) jetpackRequire
   where fnName = T.unpack $ F.pathToFunctionName filePath "js"
         requireRegex = mkRegex $ "require\\(['\"]" ++ requiredAs ++ "['\"]\\)"
-        jetpackRequire = "jetpackRequire(" ++ fnName ++ ")"
+        jetpackRequire = "jetpackRequire(" ++ fnName ++ ", \"" ++ fnName ++ "\")"
 
 compilesToJs :: Dependency -> Bool
 compilesToJs Dependency { filePath, fileType } =
@@ -113,23 +113,23 @@ addBoilerplate root fns =
   T.unlines
   [ "(function() {"
   , "var jetpackCache = {};"
-  , "function jetpackRequire(fn) {"
+  , "function jetpackRequire(fn, fnName) {"
   , "  var e = {};"
   , "  var m = { exports : e };"
   , "  if (typeof fn !== \"function\") {"
   , "    console.error(\"Required function isn't a jetpack module.\", fn)"
   , "    return;"
   , "  }"
-  , "  if (jetpackCache[fn.name]) {"
-  , "    return jetpackCache[fn.name];"
+  , "  if (jetpackCache[fnName]) {"
+  , "    return jetpackCache[fnName];"
   , "  }"
-  , "  jetpackCache[fn.name] = m.exports;"
+  , "  jetpackCache[fnName] = m.exports;"
   , "  fn(m, e);  "
-  , "  jetpackCache[fn.name] = m.exports;"
+  , "  jetpackCache[fnName] = m.exports;"
   , "  return m.exports;"
   , "}"
   , T.concat fns
-  , T.concat ["jetpackRequire(", root, ");"] -- calling the entry point
+  , T.concat ["jetpackRequire(", root, ", \"", root , "\");"] -- calling the entry point
   , "})();"
   ]
 

--- a/test/ConcatModuleSpec.hs
+++ b/test/ConcatModuleSpec.hs
@@ -92,24 +92,24 @@ expectedOutput =
   [ T.unpack $ T.unlines
     [ "(function() {"
     , "var jetpackCache = {};"
-    , "function jetpackRequire(fn) {"
+    , "function jetpackRequire(fn, fnName) {"
     , "  var e = {};"
     , "  var m = { exports : e };"
     , "  if (typeof fn !== \"function\") {"
     , "    console.error(\"Required function isn't a jetpack module.\", fn)"
     , "    return;"
     , "  }"
-    , "  if (jetpackCache[fn.name]) {"
-    , "    return jetpackCache[fn.name];"
+    , "  if (jetpackCache[fnName]) {"
+    , "    return jetpackCache[fnName];"
     , "  }"
-    , "  jetpackCache[fn.name] = m.exports;"
+    , "  jetpackCache[fnName] = m.exports;"
     , "  fn(m, e);  "
-    , "  jetpackCache[fn.name] = m.exports;"
+    , "  jetpackCache[fnName] = m.exports;"
     , "  return m.exports;"
     , "}"
     ,"/* START: test___fixtures___concat___modules___Page___Foo_js_js */"
     ,"function test___fixtures___concat___modules___Page___Foo_js_js(module, exports) {"
-    ,"var moo = jetpackRequire(test___fixtures___concat___sources___Page___Moo_js_js);"
+    ,"var moo = jetpackRequire(test___fixtures___concat___sources___Page___Moo_js_js, \"test___fixtures___concat___sources___Page___Moo_js_js\");"
     ,"moo(4, 2);"
     ,"} /* END: test___fixtures___concat___modules___Page___Foo_js_js */"
     ,"/* START: test___fixtures___concat___sources___Page___Moo_js_js */"
@@ -119,7 +119,7 @@ expectedOutput =
     ,"};"
     ,"} /* END: test___fixtures___concat___sources___Page___Moo_js_js */"
     ,""
-    ,"jetpackRequire(test___fixtures___concat___modules___Page___Foo_js_js);"
+    ,"jetpackRequire(test___fixtures___concat___modules___Page___Foo_js_js, \"test___fixtures___concat___modules___Page___Foo_js_js\");"
     ,"})();"
     ]
   ]
@@ -133,12 +133,12 @@ suite =
         wrapModule "" "" @?= ""
     , testCase "#wrapModule wraps a module in a function" $ do
         wrapModule "testFunction" mockModule @?= wrappedModule
-    , testCase "#replaceRequire replaces require(string) with jetpackRequire(function)" $ do
+    , testCase "#replaceRequire replaces require(string) with jetpackRequire(function, fnName)" $ do
         replaceRequire (mockDependency "foo" $ "ui" </> "src" </> "foo") "var x = require('foo')"
-        @?= "var x = jetpackRequire(ui___src___foo_js)"
-    , testCase "#replaceRequire replaces require(string) with jetpackRequire(function)" $ do
+        @?= "var x = jetpackRequire(ui___src___foo_js, \"ui___src___foo_js\")"
+    , testCase "#replaceRequire replaces require(string) with jetpackRequire(function, fnName)" $ do
         replaceRequire (mockDependency "foo" $ "ui" </> "src" </> "foo") "var x = require(\"foo\")"
-        @?= "var x = jetpackRequire(ui___src___foo_js)"
+        @?= "var x = jetpackRequire(ui___src___foo_js, \"ui___src___foo_js\")"
     , testCase "#wrap" $ do
     e <- runTask $ do
       modify (\env -> env { config = mockConfig })


### PR DESCRIPTION
fixes #5 

### What Changed?

* we pass the function name as a second argument to `jetpackRequire` and use that to cash stuff.

### Example Output
```js
(function() {
var jetpackCache = {};
function jetpackRequire(fn, fnName) {
  var e = {};
  var m = { exports : e };
  if (typeof fn !== "function") {
    console.error("Required function isn't a jetpack module.", fn)
    return;
  }
  if (jetpackCache[fnName]) {
    return jetpackCache[fnName];
  }
  jetpackCache[fnName] = m.exports;
  fn(m, e);  
  jetpackCache[fnName] = m.exports;
  return m.exports;
}
/* START: app___assets___modules___join2_js_js */
function app___assets___modules___join2_js_js(module, exports) {
jetpackRequire(ui___src___ChooseInterests___join2_coffee_js, "ui___src___ChooseInterests___join2_coffee_js")
} /* END: app___assets___modules___join2_js_js */
/* START: ui___src___ChooseInterests___join2_coffee_js */
function ui___src___ChooseInterests___join2_coffee_js(module, exports) {
(function() {
  $(function() {
    return analytics.trackForm($("#join2-form"), "Join Interests Submit");
  });

}).call(this);
} /* END: ui___src___ChooseInterests___join2_coffee_js */

jetpackRequire(app___assets___modules___join2_js_js, "app___assets___modules___join2_js_js");
})();
```