### PR TITLE
passing an entry point is always from the current root

### DIFF
--- a/src/EntryPoints.hs
+++ b/src/EntryPoints.hs
@@ -10,27 +10,29 @@ import Control.Monad.Except (throwError)
 
 import Error
 import qualified System.Directory as Dir
-import System.FilePath ((</>), makeRelative)
+import System.FilePath ((</>), makeRelative, normalise, takeDirectory)
 import "Glob" System.FilePath.Glob (glob)
 import Task (Task, getArgs, getConfig, toTask)
 
 find :: Task [FilePath]
 find = do
-  Config {entry_points} <- Task.getConfig
-  Args {entryPointGlob} <- Task.getArgs
-  let (root, glob) =
-        case entryPointGlob of
-          Just entryPoints -> ("", entryPoints)
-          Nothing -> (entry_points, "**" </> "*.*")
-  paths <- findFilesIn root glob
+  config <- Task.getConfig
+  args <- Task.getArgs
+  let entryPointsGlob = normalisedEntryPointsGlob config args
+  paths <- findFilesIn entryPointsGlob
   cwd <- toTask Dir.getCurrentDirectory
   case paths of
-    [] -> throwError [NoModulesPresent $ show root]
-    _ -> return $ (makeRelative $ cwd </> entry_points) <$> paths
+    [] -> throwError [NoModulesPresent $ show (takeDirectory entryPointsGlob)]
+    _ -> return $ (makeRelative $ cwd </> entry_points config) <$> paths
 
-{-| Returns a list of files in the given direcory and all it's subdirectories.
--}
-findFilesIn :: FilePath -> FilePath -> Task [FilePath]
-findFilesIn path userGlob = do
-  let globi = path </> userGlob
-  toTask $ glob globi
+normalisedEntryPointsGlob :: Config -> Args -> FilePath
+normalisedEntryPointsGlob config args =
+    case entryPointGlob args of
+      Nothing ->
+        entry_points config </> "**" </> "*.*"
+      Just entryPoints ->
+        -- handle arguments with and without a leading "./"
+        "." </> (normalise entryPoints)
+
+findFilesIn :: FilePath -> Task [FilePath]
+findFilesIn = toTask . glob


### PR DESCRIPTION
I think it's a lot nicer to have `--entry` take a full path that way you can use autocompletion to find the right module.

This is particularly nice if we go with #20 than we don't need an extra script for development. we can just use `jetpack-watcher`.

## Before

`jetpack-watch --entry "learn/quiz/playground.js"`

## After
`jetpack-watch --entry "./app/assets/modules/learn/quiz/playground.js"`