### PR TITLE
Log time to compile stuff

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,8 @@ dependencies:
 - terminal-size == 0.3.2.1
 - text == 1.2.2.2
 - time == 1.6.0.1
+- clock == 0.7.2
+- formatting == 6.2.5
 - transformers == 0.5.2.0
 - unix == 2.7.2.1
 - fsnotify == 0.2.1.1

--- a/src/CliArguments.hs
+++ b/src/CliArguments.hs
@@ -22,6 +22,7 @@ defaultArguments =
   , postHook = Nothing
   , preHook = Nothing
   , version = False
+  , time = False
   }
 
 readArguments :: Task Args
@@ -50,7 +51,8 @@ parser =
     (maybeReader go)
     (long "post-hook" <> value Nothing <>
      help "Bash commands that will get executed after jetpack runs.") <*>
-  switch (long "version" <> short 'v' <> help "display the version of jetpack")
+  switch (long "version" <> short 'v' <> help "display the version of jetpack") <*>
+  switch (long "time" <> short 't' <> help "display compile times.")
   where
     go :: String -> Maybe (Maybe String)
     go "" = Just Nothing

--- a/src/Env.hs
+++ b/src/Env.hs
@@ -26,6 +26,7 @@ data Args = Args
   , preHook :: Maybe String
   , postHook :: Maybe String
   , version :: Bool
+  , time :: Bool
   }
 
 data Config = Config

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -80,6 +80,7 @@ compileProgram args
   modules <- P.async $ fmap P.concatModule deps
   _ <- P.outputCreatedModules modules
   _ <- P.endProgress
+  _ <- traverse (\(file, duration, _, _) -> P.time file duration) out
   -- HOOK
   _ <- maybeRunHook Post (CliArguments.postHook args)
   -- RETURN WARNINGS IF ANY

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -2,6 +2,7 @@ module Logger
   ( clearLog
   , appendLog
   , compileLog
+  , compileTime
   , preHookLog
   , postHookLog
   , allLogs
@@ -12,15 +13,17 @@ import Data.Text as T
 import System.FilePath ((</>))
 import Task
 
-compileLog, preHookLog, postHookLog :: T.Text
+compileLog, compileTime, preHookLog, postHookLog :: T.Text
 compileLog = "compile.log"
+
+compileTime = "compile.time"
 
 preHookLog = "pre-hook.log"
 
 postHookLog = "post-hook.log"
 
 allLogs :: [T.Text]
-allLogs = [compileLog, preHookLog, postHookLog]
+allLogs = [compileTime, compileLog, preHookLog, postHookLog]
 
 appendLog :: T.Text -> T.Text -> Task ()
 appendLog fileName msg = do

--- a/src/Message.hs
+++ b/src/Message.hs
@@ -1,6 +1,7 @@
 module Message where
 
 import qualified Data.Maybe as M
+import Data.Semigroup ((<>))
 import qualified Data.Text as T
 import qualified Error
 import Rainbow
@@ -11,11 +12,16 @@ import qualified System.Console.Terminal.Size as TermSize
 termWidth :: IO Int
 termWidth = max 20 <$> M.maybe 20 TermSize.width <$> TermSize.size
 
-success :: IO ()
-success = do
+success :: [T.Text] -> IO ()
+success entrypoints = do
   width <- termWidth
   _ <- putChunkLn (separator width "*" & fore green)
   _ <- putChunkLn (message width "Compilation Succeeded" & fore green)
+  _ <-
+    traverse
+      (\entry ->
+         putChunkLn ((chunk $ center width $ "* " <> entry) & fore green))
+      entrypoints
   putChunkLn (separator width "*" & fore green)
 
 error :: [Error.Error] -> IO ()

--- a/src/Pipeline.hs
+++ b/src/Pipeline.hs
@@ -5,6 +5,7 @@
 module Pipeline where
 
 import CliArguments (Args)
+import Compile (Duration)
 import Config (Config)
 import Control.Monad.Free (Free, liftF)
 import qualified Data.Text as T
@@ -25,7 +26,7 @@ data PipelineF next
                    (DependencyTree -> next)
   | Compile ToolPaths
             Dependency
-            ((T.Text, Maybe T.Text) -> next)
+            ((FilePath, Duration, T.Text, Maybe T.Text) -> next)
   | Init (ToolPaths -> next)
   | ConcatModule DependencyTree
                  (FilePath -> next)
@@ -96,7 +97,10 @@ findEntryPoints = liftF $ FindEntryPoints id
 findDependency :: Dependencies -> FilePath -> Pipeline DependencyTree
 findDependency cache entryPoint = liftF $ FindDependency cache entryPoint id
 
-compile :: ToolPaths -> Dependency -> Pipeline (T.Text, Maybe T.Text)
+compile ::
+     ToolPaths
+  -> Dependency
+  -> Pipeline (FilePath, Duration, T.Text, Maybe T.Text)
 compile toolPaths dep = liftF $ Compile toolPaths dep id
 
 setup :: Pipeline ToolPaths

--- a/src/Pipeline.hs
+++ b/src/Pipeline.hs
@@ -47,6 +47,9 @@ data PipelineF next
              next
   | Hook String
          (T.Text -> next)
+  | Time FilePath
+         Duration
+         next
   | Version (T.Text -> next)
   | forall a. Async [Pipeline a]
                     ([a] -> next)
@@ -70,6 +73,7 @@ instance Functor PipelineF where
   fmap f (ClearLog fileName next) = ClearLog fileName (f next)
   fmap f (Hook hookScript g) = Hook hookScript (f . g)
   fmap f (Version g) = Version (f . g)
+  fmap f (Time file duration next) = Time file duration (f next)
   fmap f (Async commands g) = Async commands (f . g)
 
 type Pipeline = Free PipelineF
@@ -132,6 +136,9 @@ clearLog fileName = liftF $ ClearLog fileName ()
 
 hook :: String -> Pipeline T.Text
 hook hookScript = liftF $ Hook hookScript id
+
+time :: FilePath -> Duration -> Pipeline ()
+time file duration = liftF $ Time file duration ()
 
 version :: Pipeline T.Text
 version = liftF $ Version id


### PR DESCRIPTION
partially paired with @cachar 
displays compile time information if you pass `--time` and it always creates a file containing the compilation times: `.jetpack/logs/compile.time`
![screen shot 2018-02-02 at 16 48 20](https://user-images.githubusercontent.com/1217681/35741829-125bb746-0839-11e8-8e7d-5caee42264c1.png)
