### PR TITLE
Allow installing with `--ignore-scripts`

### DIFF
--- a/package/npm/.gitignore
+++ b/package/npm/.gitignore
@@ -1,3 +1,2 @@
 /node_modules/
-/bin/
 /unpacked_bin/

--- a/package/npm/bin/jetpack
+++ b/package/npm/bin/jetpack
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// This file exists for the benefit of npm users who have --ignore-scripts
+// enabled. (Enabling this flag globally is a good security measure.)
+// Since they won't run the post-install hook, the binaries won't be downloaded
+// and installed.
+//
+// Since this file is included in "bin" in package.json, npm will install
+// it automatically in a place that should be on the PATH. All the file does
+// is to download the appropriate binary (just like the post-install hook would
+// have), replace this file with that binary, and run the binary.
+//
+// In this way, the first time a user with --ignore-scripts enabled runs this
+// binary, it will download and install itself, and then run as normal. From
+// then on, it will run as normal without re-downloading.
+
+var install = require("..").install;
+var spawn = require("child_process").spawn;
+var path = require("path");
+var fs = require("fs");
+
+// Make sure we get the right path even if we're executing from the symlinked
+// node_modules/.bin/ executable
+var targetPath = fs.realpathSync(process.argv[1]);
+
+console.log("Finishing setup for first run...\n");
+
+// cd into the directory above bin/ so install() puts bin/ in the right place.
+process.chdir(path.join(path.dirname(targetPath), ".."));
+
+install(process.platform, process.arch).then(function() {
+  spawn(targetPath, process.argv.slice(2), {
+    stdio: "inherit"
+  }).on("exit", process.exit);
+});

--- a/package/npm/index.js
+++ b/package/npm/index.js
@@ -5,7 +5,6 @@ var binVersion = require(path.join(__dirname, "package.json"));
 
 var root = "https://github.com/NoRedInk/jetpack/releases/download/" + binVersion.version + "/jetpack";
 
-          'https://github.com/NoRedInk/jetpack/releases/download/2.0.15/jetpack-linux.tar.gz'
 module.exports = binwrap({
   binaries: ["jetpack"],
   urls: {

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.18",
   "description": "Install jetpack",
   "preferGlobal": true,
+  "engines": {
+    "node": ">=5.2.0"
+  },
   "main": "index.js",
   "scripts": {
     "install": "npx binwrap-install",

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -24,7 +24,9 @@
     "url": "https://github.com/NoRedInk/jetpack/issues"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "bin",
+    "bin/jetpack"
   ],
   "homepage": "https://github.com/NoRedInk/jetpack",
   "bin": {

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -21,8 +21,7 @@
     "url": "https://github.com/NoRedInk/jetpack/issues"
   },
   "files": [
-    "index.js",
-    "bin"
+    "index.js"
   ],
   "homepage": "https://github.com/NoRedInk/jetpack",
   "bin": {


### PR DESCRIPTION
See https://github.com/avh4/binwrap/pull/10

This makes it so you can now install Jetpack using `--ignore-scripts`!