### PR TITLE
Check Elm Stuff Consistency

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -47,22 +47,6 @@ printResult result =
       _ <- Message.error $ T.pack "Failed!"
       System.Exit.exitFailure
 
-checkElmArtifact :: FilePath -> IO ()
-checkElmArtifact filePath = do
-  case takeExtension filePath of
-    ".elmi" -> checkFile filePath ".elmo"
-    ".elmo" -> checkFile filePath ".elmi"
-    _ -> return ()
-  where
-    checkFile path ext = do
-      fileExists <- Dir.doesFileExist $ replaceExtension path ext
-      when (not fileExists) $ Dir.removeFile path
-
-checkElmStuffConsistency :: Config.Config -> IO ()
-checkElmStuffConsistency Config.Config {elmRoot} = do
-  files <- Glob.glob $ elmRoot </> "elm-stuff/0.19.0/*.elm[io]"
-  traverse_ checkElmArtifact files
-
 buildHelp :: Config.Config -> Args -> IO [FilePath]
 buildHelp config args = do
   toolPaths <- Init.setup config
@@ -100,6 +84,22 @@ buildHelp config args = do
        traverse (Compile.printTime args) result
   -- RETURN WARNINGS IF ANY
   return entryPoints
+
+checkElmArtifact :: FilePath -> IO ()
+checkElmArtifact filePath = do
+  case takeExtension filePath of
+    ".elmi" -> checkFile filePath ".elmo"
+    ".elmo" -> checkFile filePath ".elmi"
+    _ -> return ()
+  where
+    checkFile path ext = do
+      fileExists <- Dir.doesFileExist $ replaceExtension path ext
+      when (not fileExists) $ Dir.removeFile path
+
+checkElmStuffConsistency :: Config.Config -> IO ()
+checkElmStuffConsistency Config.Config {elmRoot} = do
+  files <- Glob.glob $ elmRoot </> "elm-stuff/0.19.0/*.elm[io]"
+  traverse_ checkElmArtifact files
 
 createdModulesJson :: ProgressBar -> Config -> [FilePath] -> IO ()
 createdModulesJson pg config paths = do

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -85,11 +85,13 @@ buildHelp config args = do
   return entryPoints
 
 checkElmStuffConsistency :: Config.Config -> IO ()
-checkElmStuffConsistency Config.Config {elmRoot} = do
+checkElmStuffConsistency config@Config.Config {elmRoot} = do
   files <-
     mconcat .
     filter ((/=) 2 . length) . L.groupBy sameModule . L.sortBy sortModules <$>
     Glob.glob (elmRoot </> "elm-stuff/0.19.0/*.elm[io]")
+  Logger.appendLog config Logger.consistencyLog . mconcat $
+    L.intersperse "\n" $ fmap T.pack files
   traverse_ Dir.removeFile files
 
 sameModule :: FilePath -> FilePath -> Bool

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -2,6 +2,7 @@ module Logger
   ( clearLog
   , appendLog
   , compileLog
+  , consistencyLog
   , compileTime
   , allLogs
   ) where
@@ -11,13 +12,15 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import System.FilePath ((<.>), (</>))
 
-compileLog, compileTime :: FilePath
+compileLog, compileTime, consistencyLog :: FilePath
 compileLog = "compile" <.> "log"
 
 compileTime = "compile" <.> "time"
 
+consistencyLog = "elm-stuff__consistency" <.> "log"
+
 allLogs :: [FilePath]
-allLogs = [compileTime, compileLog]
+allLogs = [compileTime, compileLog, consistencyLog]
 
 appendLog :: Config -> FilePath -> T.Text -> IO ()
 appendLog Config {logDir} fileName msg =


### PR DESCRIPTION
Hey @stoeffel, here's some of those changes we worked on.

I also added a check for any `.elmo` files that exist without a matching `.elmi`. I know you mentioned adding some logging, however I decided to leave that out for now. I didn't want to misinterpret some of the intentions behind the existing logging logic.

Thanks, and let me know if I can be of any more help!