### PR TITLE
Upgrade binwrap to remove tar security alert

### DIFF
--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noredink/jetpack",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Install jetpack",
   "preferGlobal": true,
   "engines": {

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -35,7 +35,7 @@
     "jetpack": "bin/jetpack"
   },
   "dependencies": {
-    "binwrap": "^0.2.0"
+    "binwrap": "0.2.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Doing security triage. This is the same `tar` issue that's affecting all the Elm things.